### PR TITLE
Fix env config usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,11 +8,37 @@ from src.auth.session import init_session, login_user, logout_user as session_lo
 load_dotenv()
 for key, value in st.secrets.items():
     os.environ[str(key)] = str(value)
+
+AUTH_TYPE = os.environ.get('AUTH_TYPE', 'google').lower()
 logging_level = os.environ.get('LOG_LEVEL', 'INFO')
 numeric_level = getattr(logging, logging_level.upper(), logging.INFO)
 logging.basicConfig(level=numeric_level, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+from src.app_config import build_auth_config
 st.set_page_config(page_title='Task Management System', page_icon='✅', layout='wide', initial_sidebar_state='expanded')
+
+def create_auth(auth_type: str):
+    if auth_type == 'auth0':
+        from src.auth.auth0_auth import Auth0Auth
+    else:
+        from aiclub_auth_lib.oauth import AIClubGoogleAuth
+    config = build_auth_config(auth_type)
+    if auth_type == 'auth0':
+        auth = Auth0Auth(config)
+
+        def perform_logout():
+            for key in list(st.session_state.keys()):
+                del st.session_state[key]
+            logout_url = f"https://{config['domain']}/v2/logout?client_id={config['client_id']}&returnTo={config['redirect_uri']}"
+            st.markdown(f'<meta http-equiv="refresh" content="0; url={logout_url}">', unsafe_allow_html=True)
+    else:
+        auth = AIClubGoogleAuth(config)
+
+        def perform_logout():
+            session_logout_user()
+    return auth, perform_logout
+
+auth, perform_logout = create_auth(AUTH_TYPE)
 init_session()
 
 import langsmith

--- a/app.py
+++ b/app.py
@@ -6,8 +6,6 @@ from src.ui.navigation import render_main_page, render_sidebar
 from src.auth.session import init_session, login_user, logout_user as session_logout_user
 
 load_dotenv()
-for key, value in st.secrets.items():
-    os.environ[str(key)] = str(value)
 
 AUTH_TYPE = os.environ.get('AUTH_TYPE', 'google').lower()
 logging_level = os.environ.get('LOG_LEVEL', 'INFO')

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -1,0 +1,16 @@
+import os
+
+def build_auth_config(auth_type: str) -> dict:
+    if auth_type == 'auth0':
+        return {
+            'domain': os.environ.get('AUTH0_DOMAIN'),
+            'client_id': os.environ.get('AUTH0_CLIENT_ID'),
+            'client_secret': os.environ.get('AUTH0_CLIENT_SECRET'),
+            'redirect_uri': os.environ.get('AUTH0_CALLBACK_URL'),
+        }
+    return {
+        'client_id': os.environ.get('GOOGLE_CLIENT_ID'),
+        'client_secret': os.environ.get('GOOGLE_CLIENT_SECRET'),
+        'redirect_uri': os.environ.get('GOOGLE_REDIRECT_URI'),
+        'allow_insecure_http': True,
+    }

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+
+st = ModuleType('streamlit')
+st.session_state = {}
+st.secrets = {}
+st.set_page_config = lambda *a, **k: None
+st.query_params = SimpleNamespace(to_dict=lambda: {})
+st.markdown = lambda *a, **k: None
+sys.modules['streamlit'] = st
+
+auth_mod = ModuleType('aiclub_auth_lib.oauth')
+class Dummy:
+    def __init__(self, config):
+        self.config = config
+auth_mod.AIClubGoogleAuth = Dummy
+sys.modules['aiclub_auth_lib.oauth'] = auth_mod
+
+dotenv = ModuleType('dotenv')
+dotenv.load_dotenv = lambda *a, **k: None
+sys.modules['dotenv'] = dotenv
+
+pd = ModuleType('pandas')
+pd.DataFrame = lambda *a, **k: None
+sys.modules['pandas'] = pd
+
+google = ModuleType('google')
+cloud = ModuleType('cloud')
+firestore = ModuleType('firestore_v1')
+firestore.FieldFilter = object
+sys.modules['google'] = google
+sys.modules['google.cloud'] = cloud
+sys.modules['google.cloud.firestore_v1'] = firestore
+
+from src.app_config import build_auth_config
+
+def test_build_auth_config(monkeypatch):
+    monkeypatch.setenv('AUTH_TYPE', 'google')
+    monkeypatch.setenv('GOOGLE_CLIENT_ID', 'cid')
+    monkeypatch.setenv('GOOGLE_CLIENT_SECRET', 'sec')
+    monkeypatch.setenv('GOOGLE_REDIRECT_URI', 'uri')
+    monkeypatch.setenv('AUTH0_DOMAIN', 'd')
+    monkeypatch.setenv('AUTH0_CLIENT_ID', 'aid')
+    monkeypatch.setenv('AUTH0_CLIENT_SECRET', 'asec')
+    monkeypatch.setenv('AUTH0_CALLBACK_URL', 'aurl')
+    cfg = build_auth_config('auth0')
+    assert cfg['domain'] == 'd'
+    assert cfg['client_id'] == 'aid'
+    assert cfg['client_secret'] == 'asec'
+    assert cfg['redirect_uri'] == 'aurl'

--- a/tests/test_app_env_startup.py
+++ b/tests/test_app_env_startup.py
@@ -1,0 +1,62 @@
+import sys
+import os
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+class Bag(dict):
+    def __getattr__(self, name):
+        return self.get(name)
+    def __setattr__(self, name, value):
+        self[name] = value
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+
+st = ModuleType('streamlit')
+st.session_state = Bag()
+st.query_params = SimpleNamespace(to_dict=lambda: {})
+st.set_page_config = lambda *a, **k: None
+st.markdown = lambda *a, **k: None
+sys.modules['streamlit'] = st
+
+auth_mod = ModuleType('aiclub_auth_lib.oauth')
+class Dummy:
+    def __init__(self, config):
+        self.config = config
+auth_mod.AIClubGoogleAuth = Dummy
+sys.modules['aiclub_auth_lib.oauth'] = auth_mod
+
+auth0_mod = ModuleType('src.auth.auth0_auth')
+class Dummy0:
+    def __init__(self, config):
+        self.config = config
+auth0_mod.Auth0Auth = Dummy0
+sys.modules['src.auth.auth0_auth'] = auth0_mod
+
+session_mod = ModuleType('src.auth.session')
+session_mod.init_session = lambda: None
+session_mod.login_user = lambda *a, **k: None
+session_mod.logout_user = lambda *a, **k: None
+sys.modules['src.auth.session'] = session_mod
+
+ui_mod = ModuleType('src.ui.navigation')
+ui_mod.render_login_page = lambda *a, **k: None
+ui_mod.render_main_page = lambda *a, **k: None
+ui_mod.render_sidebar = lambda *a, **k: None
+sys.modules['src.ui.navigation'] = ui_mod
+
+dotenv = ModuleType('dotenv')
+dotenv.load_dotenv = lambda *a, **k: None
+sys.modules['dotenv'] = dotenv
+
+os.environ['AUTH_TYPE'] = 'google'
+os.environ['GOOGLE_CLIENT_ID'] = 'cid'
+os.environ['GOOGLE_CLIENT_SECRET'] = 'sec'
+os.environ['GOOGLE_REDIRECT_URI'] = 'uri'
+
+app = __import__('app')
+
+
+def test_app_uses_env_vars():
+    assert isinstance(app.auth.config, dict)
+    assert app.auth.config['client_id'] == 'cid'


### PR DESCRIPTION
## Summary
- centralize auth config in `src/app_config.py`
- load auth details from environment variables in `app.py`
- add regression test for env configuration

## Testing
- `pip install -r requirements.txt` *(fails: unable to access 'https://github.com/amit-sw/aiclub_google_auth.git')*
- `pytest -v` *(fails: ModuleNotFoundError for several dependencies)*
- `pytest tests/test_app_config.py -v`

------
https://chatgpt.com/codex/tasks/task_e_68464824644483329312678bc62a0c50