### PR TITLE
Fix missing google cloud package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ langchain-openai
 langchain_community
 openai
 python-dotenv
+google-cloud-firestore
 pytest
 PyJWT>=2.0
 git+https://github.com/amit-sw/aiclub_google_auth.git

--- a/src/database/firestore.py
+++ b/src/database/firestore.py
@@ -3,7 +3,10 @@ import json
 import logging
 from datetime import datetime
 from typing import Dict, List, Optional, Any, Union
-from google.cloud.firestore_v1 import FieldFilter
+try:
+    from google.cloud.firestore_v1 import FieldFilter
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError('google-cloud-firestore is not installed') from e
 import firebase_admin
 from firebase_admin import credentials, firestore
 from firebase_admin.firestore import SERVER_TIMESTAMP


### PR DESCRIPTION
## Summary
- handle missing `google.cloud.firestore_v1` import
- add `google-cloud-firestore` dependency

## Testing
- `pip install -r requirements.txt` *(fails: unable to access git URL)*
- `pytest -v` *(fails: ModuleNotFoundError: google-cloud-firestore)*

------
https://chatgpt.com/codex/tasks/task_e_68465983bc78833287e235f89e68841c